### PR TITLE
ci: use ubuntu-slim runner for lightweight jobs (#1858)

### DIFF
--- a/.github/workflows/automod.yml
+++ b/.github/workflows/automod.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   comment-filter:
     name: Comment filter
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     permissions:
       issues: write # delete spam
     steps:

--- a/.github/workflows/checksum.yml
+++ b/.github/workflows/checksum.yml
@@ -4,7 +4,7 @@
 
 name: installer-checksum
 permissions: {}
-on: 
+on:
   pull_request:
     branches:
       - live
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   verify-installer-checksum:
     name: Installer Checksum Verification
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     permissions:
       contents: read
     steps:

--- a/.github/workflows/justlint.yml
+++ b/.github/workflows/justlint.yml
@@ -19,11 +19,9 @@ concurrency:
 jobs:
   bluebuild:
     name: Just lint
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     permissions:
       contents: read
-    strategy:
-      fail-fast: false 
 
     steps:
       - name: Checkout repo
@@ -32,7 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: Lint justfiles
-        run: |          
+        run: |
           sudo apt-get install pipx
           pipx install rust-just
           find "./files/justfiles" -type f -name "*.just" | while read -r file; do

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -18,7 +18,7 @@ jobs:
   verify-provenance:
     name: Verify provenance
     if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     permissions:
       packages: read # needed to pull images
     steps:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   ruff:
     name: Ruff (Python linter)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -38,7 +38,7 @@ jobs:
           ruff==0.13.0 \
             --hash=sha256:03447f3d18479df3d24917a92d768a89f873a7181a064858ea90a804a7538991
           ' > requirements.txt
-          
+
           python -m pip install --require-hashes -r requirements.txt
 
       - name: Run Ruff

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   run_tests:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     permissions:
       contents: read
     name: Install Bats and run tests

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     name: Trivy
     if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     permissions:
       security-events: write # write findings to github
     steps:

--- a/.github/workflows/update-modules.yml
+++ b/.github/workflows/update-modules.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   update-modules:
     name: Update BlueBuild modules
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     permissions:
       contents: write  # needed to create branch
       pull-requests: write  # needed to create pull request

--- a/.github/workflows/update-po.yml
+++ b/.github/workflows/update-po.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   update-po:
     name: Update PO files
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     permissions:
       contents: write  # needed to create branch
       pull-requests: write  # needed to create pull request

--- a/.github/workflows/validate_exec_bit.yml
+++ b/.github/workflows/validate_exec_bit.yml
@@ -4,7 +4,7 @@
 
 name: validate-exec-bit
 permissions: {}
-on: 
+on:
   pull_request:
     branches:
       - live
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   validate-exec-bit:
     name: Validate exec bit
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Jobs that have a very short runtime and don't require tools like Docker or much computational power can use the cheaper and less resource-intensive `ubuntu-slim` runners, which are lightweight containers with 1 vCPU and 5 GB RAM.

Also remove useless `strategy` block from justlint.yml (it does nothing without a `matrix` key).